### PR TITLE
Add default tooltip for label

### DIFF
--- a/stories/molecules/inputs/InputLabel/InputLabel.tsx
+++ b/stories/molecules/inputs/InputLabel/InputLabel.tsx
@@ -41,10 +41,13 @@ const InputLabel: FC<IInputLabelProps> = ({
 		{ "inline-block  transition-all text-sm text-gray-700 mb-1": !isPlaceholder },
 		{ "block w-full": fullWidthLabel }
 	);
+
 	if (!label) return null;
 	return (
 		<label htmlFor={id} className={labelStyles}>
-			<div className={truncateLabel ? "break-all line-clamp-1" : ""}>{label}</div>
+			<div className={truncateLabel ? "break-all line-clamp-1" : ""} title={label}>
+				{label}
+			</div>
 			{isRequired && <span className="text-red-500"> *</span>}
 		</label>
 	);


### PR DESCRIPTION
We don't have tooltip in plenum set up yet, adding a label here will at least have a browser default one show up when we show a long filter item in the DropdownWithMultiSelect component

![image](https://github.com/user-attachments/assets/151d7573-8bcd-4fd4-acb2-e2e97dda9c24)
