### PR TITLE
Fix inputRef leaking onto <input> DOM element

### DIFF
--- a/stories/molecules/inputs/InputField/InputField.tsx
+++ b/stories/molecules/inputs/InputField/InputField.tsx
@@ -40,7 +40,6 @@ export interface IInputFieldProps extends Omit<React.InputHTMLAttributes<HTMLInp
 	clientSideCheck?: boolean;
 	/** Placeholder text */
 	placeholder?: string;
-	/**ref for input */
 }
 
 const InputField = (
@@ -58,8 +57,10 @@ const InputField = (
 		clientSideCheck = true,
 		className,
 		placeholder,
+		// Strip non-DOM props that callers may pass via spread so they don't leak to the <input>.
+		inputRef: _inputRef,
 		...rest
-	}: IInputFieldProps,
+	}: IInputFieldProps & { inputRef?: React.Ref<HTMLInputElement> },
 	ref: React.Ref<HTMLInputElement>
 ) => {
 	return (

--- a/stories/organisms/FormInputWithAddons/FormInputWithAddons.tsx
+++ b/stories/organisms/FormInputWithAddons/FormInputWithAddons.tsx
@@ -99,25 +99,22 @@ const FormInputWithAddons: React.FC<IFormInputWithAddonsProps> = ({
 					</label>
 				)}
 				<InputField
-					{...{
-						...rest,
-						handleChange,
-						value,
-						id,
-						name,
-						type,
-						autoComplete: "off",
-						disabled: isDisabled,
-						placeholder: placeholder || "",
-						isReadonly,
-						isError,
-						className,
-						// add padding to accomodate inner labels and icons
-						style: {
-							paddingRight: `${trailLabelWidth + addonOffset}px`,
-							paddingLeft: `${leadLabelWidth + addonOffset}px`
-						},
-						inputRef
+					{...rest}
+					ref={inputRef}
+					handleChange={handleChange}
+					value={value}
+					id={id}
+					name={name}
+					type={type}
+					autoComplete="off"
+					disabled={isDisabled}
+					placeholder={placeholder || ""}
+					isReadonly={isReadonly}
+					isError={isError}
+					className={className}
+					style={{
+						paddingRight: `${trailLabelWidth + addonOffset}px`,
+						paddingLeft: `${leadLabelWidth + addonOffset}px`
 					}}
 				/>
 				{(trailLabel || trailIcon) && (

--- a/stories/organisms/FormInputWithAddons/tests/FormInputWithAddons.test.tsx
+++ b/stories/organisms/FormInputWithAddons/tests/FormInputWithAddons.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { vi } from "vitest";
+import { render } from "@testing-library/react";
+import FormInputWithAddons from "../FormInputWithAddons";
+
+const baseProps = {
+	id: "test-input",
+	name: "test-input",
+	type: "text" as const,
+	value: "",
+	handleChange: vi.fn()
+};
+
+describe("<FormInputWithAddons>", () => {
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		errorSpy.mockRestore();
+	});
+
+	const expectNoDomPropWarnings = () => {
+		const offending = errorSpy.mock.calls.filter(([msg]) =>
+			typeof msg === "string" &&
+			(msg.includes("React does not recognize the") ||
+				msg.includes("Unknown prop") ||
+				msg.includes("Invalid DOM property"))
+		);
+		expect(offending).toEqual([]);
+	};
+
+	it("does not warn about unknown DOM props when no inputRef is passed", () => {
+		render(<FormInputWithAddons {...baseProps} />);
+		expectNoDomPropWarnings();
+	});
+
+	it("does not leak inputRef to the underlying <input> element", () => {
+		const ref = React.createRef<HTMLInputElement>();
+		const { container } = render(<FormInputWithAddons {...baseProps} inputRef={ref} />);
+
+		expectNoDomPropWarnings();
+
+		const input = container.querySelector("input");
+		expect(input).not.toBeNull();
+		expect(input?.hasAttribute("inputref")).toBe(false);
+		expect(input?.hasAttribute("inputRef")).toBe(false);
+		// The ref should be attached to the actual input element.
+		expect(ref.current).toBe(input);
+	});
+});


### PR DESCRIPTION
## Summary
- `FormInputWithAddons` was passing `inputRef` as a regular prop into `InputField`. `InputField` didn't destructure it, so it ended up in `...rest` and was spread onto the underlying `<input>`, producing a React DOM-prop warning (`React does not recognize the inputRef prop on a DOM element`) for every consumer — even when no `inputRef` was passed.
- Fixed by forwarding the ref via `ref={inputRef}` in `FormInputWithAddons` (InputField is already a `forwardRef`), and defensively destructuring `inputRef` out of props in `InputField` so a future caller spreading `inputRef` can't reintroduce the leak.
- Audited sibling input components (`TextInput`, `TextArea`, `Select`, `TextInputSelect`, `AnimatedFormInputWithAddons`) — none of them leak.
- Added a vitest covering both the warning and the rendered DOM attribute, confirmed it fails on the unfixed code and passes after.

## Test plan
- [x] `yarn test --run` — all 14 tests across 3 files pass
- [x] New `FormInputWithAddons.test.tsx` fails on `main` and passes on this branch
- [ ] Storybook smoke check: render a story that uses `FormInputWithAddons` with and without `inputRef` and confirm the browser console no longer logs the React warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)